### PR TITLE
Python 3 compatibility (changes by `2to3`)

### DIFF
--- a/bin/gsr-branch.py
+++ b/bin/gsr-branch.py
@@ -89,12 +89,12 @@ class MyApp(cli.Application):
             # __getitem__ is the same as [] but accepts a list
             git.__getitem__(filter_branch_params) & FG
         except commands.processes.ProcessExecutionError:
-            print "Error running git filter-branch. See error above"
+            print("Error running git filter-branch. See error above")
             return False
-        print "All done!"
-        print "Check the new branch and then remove the backup ref."
-        print "To remove all backup refs, run the command:"
-        print 'git for-each-ref --format="%(refname)" refs/original/ | xargs -n 1 git update-ref -d'
+        print("All done!")
+        print("Check the new branch and then remove the backup ref.")
+        print("To remove all backup refs, run the command:")
+        print('git for-each-ref --format="%(refname)" refs/original/ | xargs -n 1 git update-ref -d')
         return True
 
     def edit(self, base, *args):
@@ -122,7 +122,7 @@ class MyApp(cli.Application):
         if delete_commit_file is not None:
             os.unlink(delete_commit_file)
         if not self.edit_internal(base, *args):
-            print "Restoring old branch state"
+            print("Restoring old branch state")
             git("reset", "--hard", old_head)
             sys.exit(1)
 

--- a/gitsearchreplace/__init__.py
+++ b/gitsearchreplace/__init__.py
@@ -19,7 +19,7 @@ def run_subprocess(cmd):
     return output
 
 def error(s):
-    print "git-search-replace: error: " + s
+    print("git-search-replace: error: " + s)
     sys.exit(-1)
 
 class Expression(object):
@@ -98,7 +98,7 @@ class GitSearchReplace(object):
         if self.separator is None:
             if len(self.expressions_str) % 2 != 0:
                 error("FROM-TO expressions not paired")
-            pairs = zip(self.expressions_str[::2], self.expressions_str[1::2])
+            pairs = list(zip(self.expressions_str[::2], self.expressions_str[1::2]))
         else:
             pairs = [expr.split(self.separator, 1) for expr in self.expressions_str]
         for fromexpr, toexpr in pairs:
@@ -146,9 +146,9 @@ class GitSearchReplace(object):
                     new_filename = filename
                     new_filename = self.sub(expr, new_filename, 'filename')
                     if new_filename != filename:
-                        print
-                        print "rename-src-file: %s" % (filename, )
-                        print "rename-dst-file: %s" % (new_filename, )
+                        print()
+                        print("rename-src-file: %s" % (filename, ))
+                        print("rename-dst-file: %s" % (new_filename, ))
                         if self.fix:
                             dirname = os.path.dirname(new_filename)
                             if dirname and not os.path.exists(dirname):
@@ -185,11 +185,11 @@ class GitSearchReplace(object):
             expr_id += 1
         shown_lines.sort()
         for line in shown_lines:
-            print line
+            print(line)
 
     def act_on_possible_modification(self, filename, new_filedata):
         if self.diff:
-            print "diff -urN a/%s b/%s" % (filename, filename)
+            print("diff -urN a/%s b/%s" % (filename, filename))
             self.show_diff(filename, new_filedata)
         if self.fix:
             fileobj = open(filename, "w")
@@ -211,17 +211,17 @@ class GitSearchReplace(object):
                     minus_matched = True
                     match = re.match("^--- ([^ ]+) (.*)$", line)
                     if match:
-                        print "--- a/%s %s" % (filename,
-                                               match.groups(0)[1], )
+                        print("--- a/%s %s" % (filename,
+                                               match.groups(0)[1], ))
                         continue
                 if not plus_matched:
                     plus_matched = True
                     match = re.match("^[+][+][+] ([^ ]+) (.*)$", line)
                     if match:
-                        print "+++ b/%s %s" % (filename,
-                                               match.groups(0)[1], )
+                        print("+++ b/%s %s" % (filename,
+                                               match.groups(0)[1], ))
                         continue
-                print line
+                print(line)
         finally:
             os.unlink(tempf)
 

--- a/gitsearchreplace/__init__.py
+++ b/gitsearchreplace/__init__.py
@@ -116,7 +116,7 @@ class GitSearchReplace(object):
         return expr.fromexpr.sub(expr.toexpr, content)
 
     def search_replace_in_files(self):
-        filenames = run_subprocess(["git", "ls-files"]).splitlines()
+        filenames = str(run_subprocess(["git", "ls-files"]), 'utf-8').splitlines()
         filtered_filenames = []
         for filename in filenames:
             excluded = False
@@ -131,9 +131,11 @@ class GitSearchReplace(object):
         for filename in filtered_filenames:
             if not os.path.isfile(filename):
                 continue
-            fileobj = file(filename)
-            filedata = fileobj.read()
-            fileobj.close()
+            with open(filename) as fileobj:
+                try:
+                    filedata = fileobj.read()
+                except UnicodeDecodeError:
+                    continue
 
             if self.diff or self.fix:
                 self.show_file(filename, filedata)


### PR DESCRIPTION
My colleague just did `pip install git-search-replace` and got a non-working setup because his `pip` is Python 3 based. This will hopefully resolve such trouble