### PR TITLE
Fix syntax warning in Python 3.13.1

### DIFF
--- a/gitsearchreplace/__init__.py
+++ b/gitsearchreplace/__init__.py
@@ -54,7 +54,7 @@ class GitSearchReplace(object):
 
     BIG_G_REGEX = re.compile(r"[\]G[{][^}]*[}]")
     def calc_big_g(self, big_g_expr):
-        """Transform the special interpolated \G{<python>}"""
+        """Transform the special interpolated \\G{<python>}"""
         parts = []
         prefix = r'\G{'
         oparts = big_g_expr.split(prefix)


### PR DESCRIPTION
(a doc-string has an invalid escape code)